### PR TITLE
metainfo: Add <translation>

### DIFF
--- a/data/metainfo/org.learningequality.Kolibri.metainfo.xml.in.in
+++ b/data/metainfo/org.learningequality.Kolibri.metainfo.xml.in.in
@@ -26,4 +26,5 @@
   </releases>
   <content_rating type="oars-1.1" />
   <update_contact>info_at_learningequality.org</update_contact>
+  <translation type="gettext">kolibri-gnome</translation>
 </component>


### PR DESCRIPTION
This will cause the appstream generator (on Flathub and elsewhere) to
consult these translations and add <languages> data to the repository's
appstream, which will in turn cause software centres like GNOME Software
to report that the app is translated into the user's language (when it
is).

Fixes #21