### PR TITLE
Fix KolibriServiceManager change callback running constantly

### DIFF
--- a/src/kolibri_gnome/kolibri_daemon/kolibri_service.py
+++ b/src/kolibri_gnome/kolibri_daemon/kolibri_service.py
@@ -317,5 +317,5 @@ class WatchChangesThread(threading.Thread):
         super().__init__(daemon=True)
 
     def run(self):
-        while self.__service_manager.wait_for_changes():
+        for _ in self.__service_manager.wait_for_changes():
             self.__callback()


### PR DESCRIPTION
Originally, the thread which watches for changes was continually getting a new generator from `KolibriServiceManager`, and then running the callback (because it is a truthy value). Instead, it should get the `wait_for_changes` generator once and loop through it, running the callback for each iteration. The previous version was causing the program to utilize 100% of a CPU.