### PR TITLE
Remove duplicate results from default search provider

### DIFF
--- a/src/kolibri_gnome_search_provider/kolibri-task-multiplexer.c
+++ b/src/kolibri_gnome_search_provider/kolibri-task-multiplexer.c
@@ -269,3 +269,18 @@ kolibri_task_multiplexer_add_next(KolibriTaskMultiplexer *self,
 
   return g_steal_pointer(&next_task);
 }
+
+/**
+ * kolibri_task_multiplexer_get_next_tasks:
+ * @self: (not nullable): A #KolibriTaskMultiplexer
+ *
+ * Get the list of tasks created by #kolibri_task_multiplexer_add_next.
+ *
+ * Returns: (not nullable) (transfer none): A #GListModel containing #GTask objects.
+ *
+ */
+GListModel *
+kolibri_task_multiplexer_get_next_tasks(KolibriTaskMultiplexer *self)
+{
+  return G_LIST_MODEL(self->next_tasks);
+}

--- a/src/kolibri_gnome_search_provider/kolibri-task-multiplexer.h
+++ b/src/kolibri_gnome_search_provider/kolibri-task-multiplexer.h
@@ -60,6 +60,8 @@ GTask *kolibri_task_multiplexer_add_next(KolibriTaskMultiplexer *self,
                                          GAsyncReadyCallback callback,
                                          gpointer callback_data);
 
+GListModel *kolibri_task_multiplexer_get_next_tasks(KolibriTaskMultiplexer *self);
+
 G_END_DECLS
 
 #endif


### PR DESCRIPTION
With this change, the default search provider only shows results if
they have not been returned by another channel-specific search provider.

https://phabricator.endlessm.com/T32560