### PR TITLE
Clean up unused names in Python sources

### DIFF
--- a/src/kolibri_app/kolibri_settings.py
+++ b/src/kolibri_app/kolibri_settings.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F401
 from kolibri.deployment.default.settings.base import *
 
 # TODO: Load SECRET_KEY from a file in $KOLIBRI_HOME

--- a/src/kolibri_daemon/dbus_utils.py
+++ b/src/kolibri_daemon/dbus_utils.py
@@ -185,7 +185,6 @@ class DBusServer(object):
 
     def notify_properties_changed(self, interface_name, properties={}):
         changed_properties = {}
-        invalidated_properties = []
 
         for property_name, property_value in properties.items():
             property_fname = self.__fname(interface_name, property_name)

--- a/src/kolibri_daemon/kolibri_service.py
+++ b/src/kolibri_daemon/kolibri_service.py
@@ -312,10 +312,6 @@ class KolibriServiceManager(KolibriServiceContext):
         if self.__stop_process and not self.__stop_process.is_alive():
             self.__stop_process = None
 
-    def watch_changes(self, callback):
-        watch_changes_thread = WatchChangesThread(self, callback)
-        watch_changes_thread.start()
-
     def start_kolibri(self):
         if self.__main_process and self.__main_process.is_alive():
             return

--- a/src/kolibri_daemon/kolibri_service_main.py
+++ b/src/kolibri_daemon/kolibri_service_main.py
@@ -1,7 +1,5 @@
 import multiprocessing
 import os
-from contextlib import contextmanager
-from pathlib import Path
 
 from kolibri_app.globals import init_kolibri
 from kolibri_app.globals import init_logging
@@ -34,7 +32,7 @@ class KolibriServiceMainProcess(multiprocessing.Process):
 
         try:
             self.__run_kolibri_start()
-        except Exception as error:
+        except Exception:
             self.__context.start_result = self.__context.StartResult.ERROR
             self.__run_kolibri_cleanup()
         finally:
@@ -68,7 +66,7 @@ class KolibriServiceMainProcess(multiprocessing.Process):
 
         self.__active_extensions.update_kolibri_environ(os.environ)
 
-        from kolibri.utils.cli import start_with_ready_cb, stop
+        from kolibri.utils.cli import start_with_ready_cb
         from kolibri.utils.conf import OPTIONS
 
         init_kolibri()

--- a/src/kolibri_daemon/kolibri_service_setup.py
+++ b/src/kolibri_daemon/kolibri_service_setup.py
@@ -8,7 +8,6 @@ import os
 import subprocess
 
 from collections import Mapping
-from pathlib import Path
 
 from kolibri_app.globals import init_kolibri
 from kolibri_app.globals import init_logging

--- a/src/kolibri_gnome/application.py
+++ b/src/kolibri_gnome/application.py
@@ -10,7 +10,6 @@ import sys
 from gettext import gettext as _
 from pathlib import Path
 from urllib.parse import parse_qs
-from urllib.parse import urlencode
 from urllib.parse import urlsplit
 
 import pew
@@ -18,8 +17,6 @@ import pew.ui
 
 from pew.pygobject_gtk.menus import PEWMenuItem
 from pew.ui import PEWShortcut
-
-import gi
 
 from gi.repository import GLib
 from gi.repository import Gtk

--- a/src/kolibri_gnome/utils.py
+++ b/src/kolibri_gnome/utils.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 from kolibri_app.globals import get_current_language

--- a/src/kolibri_gnome_launcher/application.py
+++ b/src/kolibri_gnome_launcher/application.py
@@ -2,7 +2,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-import gi
 import subprocess
 
 from urllib.parse import urlsplit
@@ -73,4 +72,3 @@ class Launcher(Gio.Application):
             kolibri_gnome_args.append(kolibri_node_url)
 
         subprocess.Popen(["kolibri-gnome", *kolibri_gnome_args])
-


### PR DESCRIPTION
Remove unused imports, unused variables, and unused method
KolibriServiceManager.watch_changes which was referencing an
inexistent WatchChangesThread name.

Using flake8 for flagging these issues.

https://phabricator.endlessm.com/T32613