### PR TITLE
kolibri-daemon: Fix autostop_timeout setter

### DIFF
--- a/src/kolibri_daemon/application.py
+++ b/src/kolibri_daemon/application.py
@@ -64,7 +64,7 @@ class PublicDBusInterface(object):
 
     @autostop_timeout.setter
     def autostop_timeout(self, value):
-        self.__stop_kolibri_timeout_interval = interval
+        self.__stop_kolibri_timeout_interval = value
 
     def init(self):
         self.__service_manager.init()


### PR DESCRIPTION
interval variable doesn't exists in the setter, the correct variable
name is value.