### PR TITLE
Fix get_loader_url parameter definition

### DIFF
--- a/src/kolibri_gnome/application.py
+++ b/src/kolibri_gnome/application.py
@@ -507,7 +507,7 @@ class Application(pew.ui.PEWApp):
     def is_kolibri_url(self, url):
         return self.kolibri_daemon.is_kolibri_url(url)
 
-    def get_loader_url(self):
+    def get_loader_url(self, state):
         return self.__loader_url + "#" + state
 
     def get_full_url(self, url):


### PR DESCRIPTION
The state parameter was removed in a previous commit and this is needed
here.