### PR TITLE
Rename kolibri-daemon's public d-bus interface

### DIFF
--- a/src/libkolibri_daemon_dbus/meson.build
+++ b/src/libkolibri_daemon_dbus/meson.build
@@ -34,6 +34,13 @@ kolibri_daemon_dbus_src = gnome.gdbus_codegen(
     sources: 'org.learningequality.Kolibri.Daemon.xml',
     interface_prefix: 'org.learningequality.Kolibri.',
     namespace: 'Kolibri',
+    # The public interface should be "org.learningequality.Kolibri.Daemon.Main",
+    # but at the moment it appears as "org.learningequality.Kolibri.Daemon" for
+    # compatibility with eos-kolibri's included D-Bus policy:
+    # <https://github.com/endlessm/eos-kolibri>
+    annotations: [
+        ['org.learningequality.Kolibri.Daemon', 'org.gtk.GDBus.C.Name', 'DaemonMain']
+    ],
     autocleanup: 'all'
 )
 

--- a/src/libkolibri_daemon_dbus/org.learningequality.Kolibri.Daemon.xml
+++ b/src/libkolibri_daemon_dbus/org.learningequality.Kolibri.Daemon.xml
@@ -2,7 +2,7 @@
  '-//freedesktop//DTD D-BUS Object Introspection 1.0//EN'
  'http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd'>
 <node>
-  <interface name="org.learningequality.Kolibri.Daemon.Main">
+  <interface name="org.learningequality.Kolibri.Daemon">
     <method name="Hold" />
     <method name="Release" />
     <method name="Start" />


### PR DESCRIPTION
The existing name is referenced in other projects, so we need to do a
more gradual migration.

https://phabricator.endlessm.com/T32687