### PR TITLE
Ensure kolibri-daemon has a d-bus session bus

### DIFF
--- a/src/kolibri_daemon/kolibri-daemon.in
+++ b/src/kolibri_daemon/kolibri-daemon.in
@@ -1,3 +1,7 @@
 #!/bin/sh
 
-@PYTHON@ -m "kolibri_daemon.main" $@
+if [ -z "${DBUS_SESSION_BUS_ADDRESS}" ]; then
+    dbus-run-session -- @PYTHON@ -m "kolibri_daemon.main" $@
+else
+    @PYTHON@ -m "kolibri_daemon.main" $@
+fi


### PR DESCRIPTION
We need a session bus to communicate between components. Normally,
kolibri-daemon uses the existing desktop user's session bus.

https://phabricator.endlessm.com/T32688