### PR TITLE
Disable automatic login when Kolibri is not a system service

### DIFF
--- a/src/kolibri_gnome/kolibri_context.py
+++ b/src/kolibri_gnome/kolibri_context.py
@@ -276,7 +276,10 @@ class _KolibriSetupHelper(GObject.GObject):
     ):
         self.props.is_session_cookie_ready = False
 
-        kolibri_daemon.get_login_token(self.__kolibri_daemon_on_login_token_ready)
+        if kolibri_daemon.do_automatic_login:
+            kolibri_daemon.get_login_token(self.__kolibri_daemon_on_login_token_ready)
+        else:
+            self.props.is_session_cookie_ready = True
 
     def __kolibri_daemon_on_notify_is_started(
         self, kolibri_daemon: KolibriDaemonManager, pspec: GObject.ParamSpec = None
@@ -284,6 +287,11 @@ class _KolibriSetupHelper(GObject.GObject):
         self.props.is_facility_ready = False
 
         if not self.__kolibri_daemon.props.is_started:
+            return
+
+        if not self.__kolibri_daemon.do_automatic_login:
+            # No automatic login so we don't need a facility:
+            self.props.is_facility_ready = True
             return
 
         self.__kolibri_daemon.kolibri_api_get_async(

--- a/src/kolibri_gnome/kolibri_daemon_manager.py
+++ b/src/kolibri_gnome/kolibri_daemon_manager.py
@@ -31,7 +31,7 @@ class KolibriDaemonManager(GObject.GObject):
 
     __dbus_proxy: KolibriDaemonDBus.MainProxy
 
-    __was_started: bool = False
+    __do_automatic_login: bool = False
     __did_init: bool = False
     __dbus_proxy_owner: typing.Optional[str] = None
 
@@ -46,8 +46,12 @@ class KolibriDaemonManager(GObject.GObject):
     def __init__(self):
         GObject.GObject.__init__(self)
 
+        g_bus_type = KolibriDaemonDBus.get_default_bus_type()
+
+        self.__do_automatic_login = g_bus_type == Gio.BusType.SYSTEM
+
         self.__dbus_proxy = KolibriDaemonDBus.MainProxy(
-            g_bus_type=KolibriDaemonDBus.get_default_bus_type(),
+            g_bus_type=g_bus_type,
             g_name=DAEMON_APPLICATION_ID,
             g_object_path=DAEMON_MAIN_OBJECT_PATH,
             g_interface_name=KolibriDaemonDBus.main_interface_info().name,
@@ -56,6 +60,10 @@ class KolibriDaemonManager(GObject.GObject):
             "notify::g-name-owner", self.__dbus_proxy_on_notify_g_name_owner
         )
         self.__dbus_proxy.connect("notify", self.__dbus_proxy_on_notify)
+
+    @property
+    def do_automatic_login(self) -> bool:
+        return self.__do_automatic_login
 
     def init(self):
         if self.__did_init:


### PR DESCRIPTION
Add a do_automatic_login property in the kolibri daemon manager. Use
it in the kolibri context to get or not the login token.

https://phabricator.endlessm.com/T32840