### PR TITLE
Handle D-Bus name lost when disconnected

### DIFF
--- a/src/kolibri_daemon/application.py
+++ b/src/kolibri_daemon/application.py
@@ -597,6 +597,7 @@ class Application(Gio.Application):
     def __on_system_name_acquired(self, connection: Gio.DBusConnection, name: str):
         pass
 
-    def __on_system_name_lost(self, connection: Gio.DBusConnection, name: str):
-        self.__public_interface.unexport(connection)
-        self.__private_interface.unexport(connection)
+    def __on_system_name_lost(self, connection: typing.Optional[Gio.DBusConnection], name: str):
+        if connection:
+            self.__public_interface.unexport(connection)
+            self.__private_interface.unexport(connection)


### PR DESCRIPTION
Per the GBusNameLostCallback documentation[1] (but sadly not the GI
annotations), connection can be `NULL` if the connection was already
disconnected. Trying to unexport the interfaces without a connection
results in the following traceback:

```
Traceback (most recent call last):
  File "/app/lib/python3.8/site-packages/kolibri_daemon/application.py", line 599, in __on_system_name_lost
    self.__public_interface.unexport(connection)
  File "/app/lib/python3.8/site-packages/kolibri_daemon/application.py", line 113, in unexport
    if self.__skeleton.has_connection(connection):
TypeError: Argument 1 does not allow None as a value
```

1. https://developer-old.gnome.org/gio/stable/gio-Owning-Bus-Names.html#GBusNameLostCallback