### PR TITLE
Execute commands in wrapper scripts

### DIFF
--- a/src/kolibri_daemon/kolibri-daemon.in
+++ b/src/kolibri_daemon/kolibri-daemon.in
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ -z "${DBUS_SESSION_BUS_ADDRESS}" ]; then
-    dbus-run-session -- @PYTHON@ -m "kolibri_daemon.main" $@
+    exec dbus-run-session -- @PYTHON@ -m "kolibri_daemon.main" $@
 else
-    @PYTHON@ -m "kolibri_daemon.main" $@
+    exec @PYTHON@ -m "kolibri_daemon.main" $@
 fi

--- a/src/kolibri_gnome/kolibri-gnome.in
+++ b/src/kolibri_gnome/kolibri-gnome.in
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-@PYTHON@ -m "kolibri_gnome.main" $@
+exec @PYTHON@ -m "kolibri_gnome.main" $@

--- a/src/kolibri_gnome_launcher/kolibri-gnome-launcher.in
+++ b/src/kolibri_gnome_launcher/kolibri-gnome-launcher.in
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-@PYTHON@ -m "kolibri_gnome_launcher.main" $@
+exec @PYTHON@ -m "kolibri_gnome_launcher.main" $@


### PR DESCRIPTION
All of these scripts exist just to assemble the correct python commands
and do nothing else after the command ends. Execute those commands so
there aren't useless shell processes hanging around.