### PR TITLE
Fix services initializing before daemon is ready

### DIFF
--- a/src/kolibri_daemon/application.py
+++ b/src/kolibri_daemon/application.py
@@ -453,10 +453,7 @@ class Application(Gio.Application):
         self.__search_handler = search_handler
 
         self.__public_interface = PublicDBusInterface(self, kolibri_service)
-        self.__public_interface.init()
-
         self.__private_interface = PrivateDBusInterface(self)
-        self.__private_interface.init()
 
         self.__login_token_manager = LoginTokenManager()
 
@@ -488,8 +485,6 @@ class Application(Gio.Application):
             "Timeout in seconds before stopping Kolibri",
             None,
         )
-
-        self.__begin_await_kolibri_bus_ready_timeout()
 
     @property
     def use_session_bus(self) -> bool:
@@ -566,8 +561,16 @@ class Application(Gio.Application):
         return -1
 
     def do_startup(self):
+        self.__kolibri_service.init()
+        self.__search_handler.init()
+        self.__private_interface.init()
+        self.__public_interface.init()
+
+        self.__begin_await_kolibri_bus_ready_timeout()
+
         if self.use_system_bus:
             Gio.bus_get(Gio.BusType.SYSTEM, None, self.__system_bus_on_get)
+
         Gio.Application.do_startup(self)
 
     def do_shutdown(self):

--- a/src/kolibri_daemon/main.py
+++ b/src/kolibri_daemon/main.py
@@ -20,12 +20,9 @@ def main():
     setproctitle(PROCESS_NAME)
 
     kolibri_service = KolibriServiceManager()
-    kolibri_service.init()
-
     search_handler = LocalSearchHandler()
-    search_handler.init()
-
     application = Application(kolibri_service, search_handler)
+
     signal.signal(signal.SIGTERM, partial(application_signal_handler, application))
 
     return application.run(sys.argv)


### PR DESCRIPTION
Wait until the daemon application has acquired a name before initializing its KolibriServiceManager and LocalSearchHandler.

This change fixes an issue where `kolibri-daemon --help` caused the application to start the Kolibri backend (in stopped mode) and hang forever, and where the application would hang forever if it failed to acquire a dbus name. Neither of these cases are likely to occur in the real world, but it's good to fix them.