### PR TITLE
Release version 2.3.0

### DIFF
--- a/data/metainfo/org.learningequality.Kolibri.metainfo.xml.in.in
+++ b/data/metainfo/org.learningequality.Kolibri.metainfo.xml.in.in
@@ -22,6 +22,16 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="2.3.0" date="2023-09-22" type="stable">
+      <description>
+        <p>Changes included in this release:</p>
+        <ul>
+          <li>
+            The application runtime is updated to GNOME 44.
+          </li>
+        </ul>
+      </description>
+    </release>
     <release version="2.2.1" date="2023-03-21" type="stable">
       <description>
         <p>Changes included in this release:</p>

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('kolibri-gnome', ['c'],
     meson_version: '>= 0.56.0',
-    version: '2.2.1'
+    version: '2.3.0'
 )
 
 package_string = '@0@-@1@'.format(meson.project_name(), meson.project_version())


### PR DESCRIPTION
This is to allow updating the Flatpak to the GNOME 44 runtime.