### PR TITLE
Drop deprecated STATIC_USE_SYMLINKS setting

### DIFF
--- a/build-aux/flatpak/org.learningequality.Kolibri.Devel.json
+++ b/build-aux/flatpak/org.learningequality.Kolibri.Devel.json
@@ -16,7 +16,6 @@
         "--system-talk-name=org.learningequality.Kolibri.Devel.Daemon",
         "--env=KOLIBRI_HOME=~/.var/app/org.learningequality.Kolibri.Devel/data/kolibri",
         "--env=KOLIBRI_HTTP_PORT=0",
-        "--env=KOLIBRI_STATIC_USE_SYMLINKS=0",
         "--env=PYTHONPATH=/app/kolibri-plugins/lib/python"
     ],
     "add-extensions" : {


### PR DESCRIPTION
This setting has been dropped since Kolibri 0.15.0 and is currently a no-op.

learningequality/kolibri#7792

This is a rebased version of #74 and supersedes it.