### PR TITLE
Fix an error using kolibri_api_post_async with request_body

### DIFF
--- a/src/kolibri_gnome/kolibri_daemon_manager.py
+++ b/src/kolibri_gnome/kolibri_daemon_manager.py
@@ -155,10 +155,9 @@ class KolibriDaemonManager(GObject.GObject):
         soup_session = Soup.Session.new()
         soup_message = Soup.Message.new(method, url)
         if request_body is not None:
-            soup_message.set_request(
+            soup_message.set_request_body_from_bytes(
                 "application/json",
-                Soup.MemoryUse.COPY,
-                self.__request_body_object_to_bytes(request_body),
+                GLib.Bytes(self.__request_body_object_to_bytes(request_body)),
             )
         soup_session.send_async(
             soup_message,


### PR DESCRIPTION
In `KolibriDaemonManager.__kolibri_api_call_async`, we were incorrectly calling `Soup.Message.set_request_body`. This function no longer exists in Soup 3.0. Instead, we should use `set_request_body_from_bytes`.

Closes https://github.com/learningequality/kolibri-installer-gnome/issues/92