### PR TITLE
Use paths instead of URIs in WebKit.Download

### DIFF
--- a/src/kolibri_gnome/application.py
+++ b/src/kolibri_gnome/application.py
@@ -221,7 +221,7 @@ class Application(Adw.Application):
             return
         response_file = file_chooser.get_file()
         download.set_allow_overwrite(True)
-        download.set_destination(response_file.get_uri())
+        download.set_destination(response_file.get_path())
 
     def __download_on_finished(self, download: WebKit.Download):
         download_destination = download.get_destination()
@@ -229,7 +229,7 @@ class Application(Adw.Application):
         if not download_destination:
             return
 
-        download_file = Gio.File.new_for_uri(download_destination)
+        download_file = Gio.File.new_for_path(download_destination)
 
         file_launcher = Gtk.FileLauncher.new(download_file)
         file_launcher.open_containing_folder(None, None, None)


### PR DESCRIPTION
The format of the WebKit.Download "destination" property was changed to a path instead of a URI in WebKit 6.0.

-----

WebKit 6.0 also added the ability to handle the "decide-destination" signal asynchronously, so I was tempted to do that and change these dialogs to `Gtk.FileDialog`. But we'll leave that for another day: https://github.com/learningequality/kolibri-installer-gnome/issues/97.