### PR TITLE
Add style.css and style-dark.css with headerbar colors

### DIFF
--- a/data/css/style-dark.css
+++ b/data/css/style-dark.css
@@ -1,0 +1,9 @@
+/* The colour codes here are borrowed from
+ * <https://github.com/learningequality/kolibri-design-system/blob/v4.3.0/lib/styles/colorsDefault.js#L47-L65>
+ * TODO: Include brand colours programmatically.
+ */
+
+@define-color headerbar_bg_color #E5B700; /* secondary.v_1100 */
+@define-color headerbar_fg_color #000000;
+@define-color headerbar_border_color #E5B700; /* secondary.v_1100 */
+@define-color headerbar_backdrop_color #FFCB00; /* secondary.v_1000 */

--- a/data/css/style.css
+++ b/data/css/style.css
@@ -1,0 +1,9 @@
+/* The colour codes here are borrowed from
+ * <https://github.com/learningequality/kolibri-design-system/blob/v4.3.0/lib/styles/colorsDefault.js#L47-L65>
+ * TODO: Include brand colours programmatically.
+ */
+
+@define-color headerbar_bg_color #FFEA99; /* secondary.v_400 */
+@define-color headerbar_fg_color #000000;
+@define-color headerbar_border_color #FFEA99; /* secondary.v_400 */
+@define-color headerbar_backdrop_color #FFF5CC; /* secondary.v_200 */

--- a/data/org.learningequality.Kolibri.gresource.xml.in
+++ b/data/org.learningequality.Kolibri.gresource.xml.in
@@ -2,5 +2,7 @@
 <gresources>
   <gresource prefix="@BASE_OBJECT_PATH@">
     <file preprocess="xml-stripblanks" alias="@BASE_APPLICATION_ID@.metainfo.xml">metainfo/@BASE_APPLICATION_ID@.metainfo.xml</file>
+    <file alias="style.css">css/style.css</file>
+    <file alias="style-dark.css">css/style-dark.css</file>
   </gresource>
 </gresources>


### PR DESCRIPTION
These are automatically loaded by libadwaita. Simply including them in gresource.xml is sufficient.

-----

Example screenshots:

![Screenshot from 2024-05-31 10-43-19](https://github.com/learningequality/kolibri-installer-gnome/assets/132063/c78b672e-d4c0-4ac1-9462-3c360fd83df1)

![Screenshot from 2024-05-31 10-43-43](https://github.com/learningequality/kolibri-installer-gnome/assets/132063/6d3919d3-db4b-4d8f-a986-49495f89c362)

![Screenshot from 2024-05-31 10-44-04](https://github.com/learningequality/kolibri-installer-gnome/assets/132063/6b17ebce-c71c-42db-a728-2ef48ca21d07)
